### PR TITLE
Fix border style comment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ Running `$ npm start` will process the source CSS and place the built CSS in the
    BORDER STYLES
 
    Base:
-     bs = border-style
+     b = border-style
 
    Modifiers:
      none   = none

--- a/src/tachyons-border-style.css
+++ b/src/tachyons-border-style.css
@@ -7,7 +7,7 @@
    BORDER STYLES
 
    Base:
-     bs = border-style
+     b = border-style
 
    Modifiers:
      none   = none


### PR DESCRIPTION
Silly PR, but the comment in the module still reads the base as `bs` instead of `b`.
